### PR TITLE
Add cram_convert process to config files

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -10,6 +10,9 @@
    withName: merge_sort{
    clusterOptions = "--job-name=merge_sort --time=12:00:00 --mem-per-cpu=20G --cpus-per-task=1"
    }
+   withName: cram_convert{
+   clusterOptions = "--account=nn10082k --job-name=cram_convert --time=18:00:00 --mem-per-cpu=20G --cpus-per-task=1"
+   }
    withName: mark_dup{
    clusterOptions = "--job-name=mark_dup --time=24:00:00 --mem-per-cpu=20G --cpus-per-task=1"
    }
@@ -34,7 +37,7 @@
    withName: filter_vcf{
    clusterOptions = "--job-name=filter --time=12:00:00 --mem-per-cpu=12G --cpus-per-task=2"
    }
-    withName: cov{
+   withName: cov{
    clusterOptions = "--job-name=cov --time=12:00:00 --mem-per-cpu=12G --cpus-per-task=1"
    }
 }

--- a/nextflow_saga.config
+++ b/nextflow_saga.config
@@ -7,6 +7,9 @@
    withName: align{
    clusterOptions = "--account=nn10082k --job-name=align --time=18:00:00 --mem-per-cpu=20G --cpus-per-task=1"
    }
+   withName: cram_convert{
+   clusterOptions = "--account=nn10082k --job-name=cram_convert --time=18:00:00 --mem-per-cpu=20G --cpus-per-task=1"
+   }
    withName: merge_sort{
    clusterOptions = "--account=nn10082k --job-name=merge_sort --time=18:00:00 --mem-per-cpu=20G --cpus-per-task=1"
    }


### PR DESCRIPTION
Pipeline crashes at beginning of cram_convert process as it is not present in the ```nextflow.config``` (and ```nextflow_saga.config```) file(s).