### PR TITLE
Repair fastqc in process trimming

### DIFF
--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -49,9 +49,7 @@ process trimming {
     path("${new_sample}.R2.trim_pair.fastq.gz"), \
     path("${new_sample}.R1.trim_unpair.fastq.gz"), \
     path("${new_sample}.R2.trim_unpair.fastq.gz"), \
-    path("${new_sample}.stats"), \
-    path("${f_read}_fastqc.zip"), \
-    path("${r_read}_fastqc.zip")
+    path("${new_sample}.stats")
 
 
     """
@@ -83,9 +81,7 @@ process align {
     path("${sample}.R2.trim_pair.fastq.gz"), \
     path("${sample}.R1.trim_unpair.fastq.gz"), \
     path("${sample}.R2.trim_unpair.fastq.gz"), \
-    path("${sample}.stats"), \
-    path("${f_read}_fastqc.zip"), \
-    path("${r_read}_fastqc.zip")
+    path("${sample}.stats")
 
     output:
     tuple \

--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -56,8 +56,8 @@ process trimming {
 
     """
     ## run fastqc
-    zcat ${f_read} | fastqc -o ./ stdin:${f_read}
-    zcat ${r_read} | fastqc -o ./ stdin:${r_read} 
+    zcat ${f_read} | fastqc -o ./ stdin:${f_read}.fastq.gz
+    zcat ${r_read} | fastqc -o ./ stdin:${r_read}.fastq.gz
 
     ## set the adapter fasta - need to find a way to change this
     ADAPT_FAST=${params.trim}/${adapter}.fa

--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -56,8 +56,8 @@ process trimming {
 
     """
     ## run fastqc
-    cat ${f_read} | fastqc -o ./ stdin:${f_read}
-    cat ${r_read} | fastqc -o ./ stdin:${r_read} 
+    zcat ${f_read} | fastqc -o ./ stdin:${f_read}
+    zcat ${r_read} | fastqc -o ./ stdin:${r_read} 
 
     ## set the adapter fasta - need to find a way to change this
     ADAPT_FAST=${params.trim}/${adapter}.fa

--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -45,13 +45,13 @@ process trimming {
     output:
     tuple \
     val(new_sample), \
-    path ("${new_sample}.R1.trim_pair.fastq.gz"), \
-    path ("${new_sample}.R2.trim_pair.fastq.gz"), \
-    path ("${new_sample}.R1.trim_unpair.fastq.gz"), \
-    path ("${new_sample}.R2.trim_unpair.fastq.gz"), \
-    path ("${new_sample}.stats"), \
-    path ("${f_read}_fastqc.zip"), \
-    path ("${r_read}_fastqc.zip")
+    path("${new_sample}.R1.trim_pair.fastq.gz"), \
+    path("${new_sample}.R2.trim_pair.fastq.gz"), \
+    path("${new_sample}.R1.trim_unpair.fastq.gz"), \
+    path("${new_sample}.R2.trim_unpair.fastq.gz"), \
+    path("${new_sample}.stats"), \
+    path("${f_read}_fastqc.zip"), \
+    path("${r_read}_fastqc.zip")
 
 
     """
@@ -84,8 +84,8 @@ process align {
     path("${sample}.R1.trim_unpair.fastq.gz"), \
     path("${sample}.R2.trim_unpair.fastq.gz"), \
     path("${sample}.stats"), \
-    path ("${f_read}_fastqc.zip"), \
-    path ("${r_read}_fastqc.zip")
+    path("${f_read}_fastqc.zip"), \
+    path("${r_read}_fastqc.zip")
 
     output:
     tuple \

--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -49,8 +49,8 @@ process trimming {
     path ("${new_sample}.R2.trim_pair.fastq.gz"), \
     path ("${new_sample}.R1.trim_unpair.fastq.gz"), \
     path ("${new_sample}.R2.trim_unpair.fastq.gz"), \
-    path ("${new_sample}.stats")
-    path ("${f_read}_fastqc.zip")
+    path ("${new_sample}.stats"), \
+    path ("${f_read}_fastqc.zip"), \
     path ("${r_read}_fastqc.zip")
 
 
@@ -83,8 +83,8 @@ process align {
     path("${sample}.R2.trim_pair.fastq.gz"), \
     path("${sample}.R1.trim_unpair.fastq.gz"), \
     path("${sample}.R2.trim_unpair.fastq.gz"), \
-    path("${sample}.stats")
-    path ("${f_read}_fastqc.zip")
+    path("${sample}.stats"), \
+    path ("${f_read}_fastqc.zip"), \
     path ("${r_read}_fastqc.zip")
 
     output:

--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -56,8 +56,8 @@ process trimming {
 
     """
     ## run fastqc
-    fastqc -o ./ $f_read
-    fastqc -o ./ $r_read 
+    cat ${f_read} | fastqc -o ./ stdin:${f_read}
+    cat ${r_read} | fastqc -o ./ stdin:${r_read} 
 
     ## set the adapter fasta - need to find a way to change this
     ADAPT_FAST=${params.trim}/${adapter}.fa

--- a/1_trim_and_align.nf
+++ b/1_trim_and_align.nf
@@ -45,12 +45,15 @@ process trimming {
     output:
     tuple \
     val(new_sample), \
+    path(f_read), \
+    path(r_read), \
     path("${new_sample}.R1.trim_pair.fastq.gz"), \
     path("${new_sample}.R2.trim_pair.fastq.gz"), \
     path("${new_sample}.R1.trim_unpair.fastq.gz"), \
     path("${new_sample}.R2.trim_unpair.fastq.gz"), \
-    path("${new_sample}.stats")
-
+    path("${new_sample}.stats"), \
+    path("${f_read}_fastqc.zip"), \
+    path("${r_read}_fastqc.zip")
 
     """
     ## run fastqc
@@ -77,11 +80,15 @@ process align {
     input:
     tuple \
     val(sample), \
+    path(f_read), \
+    path(r_read), \
     path("${sample}.R1.trim_pair.fastq.gz"), \
     path("${sample}.R2.trim_pair.fastq.gz"), \
     path("${sample}.R1.trim_unpair.fastq.gz"), \
     path("${sample}.R2.trim_unpair.fastq.gz"), \
-    path("${sample}.stats")
+    path("${sample}.stats"), \
+    path("${f_read}_fastqc.zip"), \
+    path("${r_read}_fastqc.zip")
 
     output:
     tuple \


### PR DESCRIPTION
The inclusion of FASTQC originally caused `1_trim_and_align.nf` to crash at the junction between the `trimming` and `align` processes as the filename passed to `align` was not recognised. Fix by ensuring FASTQC outputs a file name that can easily be piped to `align` while also including the necessary I/O between processes to conciliate them.